### PR TITLE
check for source file existence

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,7 +53,10 @@ func main() {
 	}
 
 	app.Action = func(c *cli.Context) error {
-
+		_, err := os.Stat(c.String(SOURCE))
+		if os.IsNotExist(err) {
+			log.Fatalf("error opening source GeoPackage: %s", err)
+		}
 		srcHandle, err := gpkg.Open(c.String(SOURCE))
 		if err != nil {
 			log.Fatalf("error opening source GeoPackage: %s", err)


### PR DESCRIPTION
# Omschrijving

de `gpkg.Open` checkt niet of het bestand bestaat. op zich logisch, als je ernaar wilt schrijven wordt het nieuw gemaakt. maar voor de source is het handig om te checken of het bestaat, denk ik.

## Type verandering

- Verbetering oude feature

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [ ] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)